### PR TITLE
addresses the TypeError raised when 'new' is None

### DIFF
--- a/nyprsetuptools/commands/deploy.py
+++ b/nyprsetuptools/commands/deploy.py
@@ -332,6 +332,17 @@ class DockerDeploy(Command):
                            for d in resp['services'][0]['deployments']}
             new = wait(deployments.pop, args=[task_definition_arn],
                        exceptions=[KeyError])
+
+            # Sometimes the 'wait' condition times out before the new task
+            # information is available. This will continue trying for the
+            # duration of the timeout.
+            if not new:
+                print('Waiting on new task information, {}s until timeout.'
+                      .format(int(self.wait)))
+                time.sleep(5)
+                self.wait = self.wait - (time.time() - start_time)
+                continue
+
             if deployments:
                 old = deployments.pop(list(deployments.keys())[0])
             else:


### PR DESCRIPTION
Sometimes this message appears on deployments:
```
Traceback (most recent call last):
  File "/home/circleci/.venv/bin/nyprsetuptools", line 7, in <module>
    run_cmd()
  File "/home/circleci/.venv/lib/python3.6/site-packages/nyprsetuptools/util/cli.py", line 55, in run_cmd
    cmd.run()
  File "/home/circleci/.venv/lib/python3.6/site-packages/nyprsetuptools/commands/deploy.py", line 396, in run
    self.update_service(cluster_name, task_name, task_definition_arn)
  File "/home/circleci/.venv/lib/python3.6/site-packages/nyprsetuptools/commands/deploy.py", line 339, in update_service
    to_start = new['desiredCount'] - new['runningCount']
TypeError: 'NoneType' object is not subscriptable
Exited with code 1
```