### PR TITLE
add optional param for installing test_requirements

### DIFF
--- a/nyprsetuptools/commands/build.py
+++ b/nyprsetuptools/commands/build.py
@@ -41,26 +41,31 @@ class InstallTestRequirements(Command):
         executed directly, for example).
     """
 
-    user_options = []
+    user_options = [
+        ('user', None, 'Pass `--user` to pip install')
+    ]
 
     @property
     def description(self):
         return self.__doc__
 
     def initialize_options(self):
-        pass
+        self.user = False
 
     def finalize_options(self):
         pass
 
     def run(self):
         import subprocess
+        cmd = ['pip', 'install']
+        if self.user:
+            cmd.append('--user')
         install_from_git = [pkg.split('=')[:len('#egg=')] for pkg
                             in self.distribution.dependency_links]
         install_from_pypi = [pkg for pkg in self.distribution.tests_require
                              if pkg not in install_from_git]
         p = subprocess.Popen(
-            ['pip', 'install'] +
+            cmd +
             self.distribution.dependency_links +
             install_from_pypi
         )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='nyprsetuptools',
-    version='0.0.15',
+    version='0.0.16',
     author='NYPR Digital',
     author_email='digitalops@nypublicradio.org',
     url='https://github.com/nypublicradio/nyprsetuptools',


### PR DESCRIPTION
new flag to pass `--user` to `pip install`. turned out to be un-necessary for the problem in question but maybe not bad to have?