### PR TITLE
adding lastUpdateStatus check to LambdaDeploy

### DIFF
--- a/nyprsetuptools/commands/deploy.py
+++ b/nyprsetuptools/commands/deploy.py
@@ -595,9 +595,13 @@ class LambdaDeploy(Command):
             # update call is still running, the build will fail and the env vars won't be
             # updated. So we need to wait until the LastUpdateStatus of the function is "Successful" instead
             # of "InProgress".
-            while client.get_function(FunctionName=function_name)['Configuration']['LastUpdateStatus'] == 'InProgress':
-                print('Waiting for code deploy before updating env vars.')
+            timeout = 0
+            while timeout < 60 and client.get_function(FunctionName=function_name)['Configuration']['LastUpdateStatus'] == 'InProgress':
+                print(f'Waiting for code deploy before updating env vars. {60 - timeout} seconds until timeout.')
                 time.sleep(5)
+                timeout += 5
+            if timeout == 60:
+                sys.exit(f"The update to {function_name} has timed out before updating the Env Vars") 
             client.update_function_configuration(
                 FunctionName=function_name,
                 Handler=function_handler,


### PR DESCRIPTION
uses a call to the `get_function` method ([link](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.get_function)) to determine whether it is safe to attempt to update the env vars after updating the code of a lambda function