### PR TITLE
added more thorough status-checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+requirements.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -106,3 +107,6 @@ newrelic.ini
 
 *.zip
 .pytest_cache
+
+# PyCharm
+.idea/

--- a/nyprsetuptools/commands/deploy.py
+++ b/nyprsetuptools/commands/deploy.py
@@ -596,7 +596,19 @@ class LambdaDeploy(Command):
             # updated. So we need to wait until the LastUpdateStatus of the function is "Successful" instead
             # of "InProgress".
             timeout = 0
-            while timeout < 60 and client.get_function(FunctionName=function_name)['Configuration']['LastUpdateStatus'] == 'InProgress':
+            while timeout < 60:
+                try:
+                    config = client.get_function(FunctionName=function_name)['Configuration']
+                    update_status = config['LastUpdateStatus']
+                except KeyError:
+                    # If there is no LastUpdateStatus key, keep waiting.
+                    continue
+                    
+                if update_status == 'Successful':
+                    break
+                elif update_status == 'Failed':
+                    sys.exit(f"The update to {function_name} failed; reason provided: {config['LastUpdateStatusReason']}")
+
                 print(f'Waiting for code deploy before updating env vars. {60 - timeout} seconds until timeout.')
                 time.sleep(5)
                 timeout += 5


### PR DESCRIPTION
`LambdaDeploy` doesn't have tests. I'm just trying to do a deploy that failed because of a `KeyError` for the `LastUpdateStatus` key. I will come back to write tests for `LambdaDeploy` when I have time to dedicate to that.