### PR TITLE
locking boto3 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
     scripts=[
         'scripts/nyprsetuptools',
     ],
+    install_requires=[
+        'boto3==1.21.2'
+    ],
     tests_require=[
         'pytest',
     ],


### PR DESCRIPTION
Version 1.21+ is required to enable update status checking that Nico added a few months ago.