### PR TITLE
with quotes

### DIFF
--- a/nyprsetuptools/commands/deploy.py
+++ b/nyprsetuptools/commands/deploy.py
@@ -165,7 +165,10 @@ class DockerDeploy(Command):
             flags.append(f'-f {self.dockerfile}')
 
         for var in env_vars:
-            flags.append(f'--build-arg {var["name"]}={var["value"]}')
+            flags.append(f'--build-arg "{var["name"]}={var["value"]}"')
+
+        for flag in flags:
+            print(flag)
 
         self.docker('build', *flags, os.getcwd())
         if self.test:


### PR DESCRIPTION
it works locally, but I'm not passing in all of the variables, so I'm thinking the error in circle is from the evaluation of the docker command produced. This should make each build-arg more explicit, such that strings with spaces or other "confusing" characters should be handled correctly now.